### PR TITLE
Fix for the bug that does not auto-update the LegCellView upon change

### DIFF
--- a/Champion/Views/Components/LegsCellView.swift
+++ b/Champion/Views/Components/LegsCellView.swift
@@ -11,13 +11,17 @@ struct LegsCellView: View {
     @Environment(\.colorScheme) var colorScheme
     private let matchCellShape = Rectangle()
     
-    let leg: MatchLeg
+    let homeParticipant: Participant
+    let awayParticipant: Participant
+    let legState: GameState
+    let winner: Participant?
+    let endedInATie: Bool
     
     var body: some View {
         HStack {
             HStack {
-                leadingImage(for: leg.homeParticipant)
-                Text(leg.homeParticipant.playerName)
+                leadingImage(for: homeParticipant)
+                Text(homeParticipant.playerName)
                     .font(.title3)
             }
             Spacer()
@@ -26,8 +30,8 @@ struct LegsCellView: View {
                 .fontWeight(.bold)
             Spacer()
             HStack {
-                leadingImage(for: leg.awayParticipant)
-                Text(leg.awayParticipant.playerName)
+                leadingImage(for: awayParticipant)
+                Text(awayParticipant.playerName)
                     .font(.title3)
                     .frame(alignment: .trailing)
             }
@@ -38,7 +42,7 @@ struct LegsCellView: View {
     }
     
     private var backgroundColor: Color {
-        if leg.legState == .completed {
+        if legState == .completed {
             return .green.opacity(0.30)
         } else {
             return colorScheme == .light ? .white : .black
@@ -47,9 +51,9 @@ struct LegsCellView: View {
     
     @ViewBuilder
     private func leadingImage(for participant: Participant) -> some View {
-        if leg.winner == participant {
+        if winner == participant {
             Image(systemName: "star.fill")
-        } else if leg.endedInATie {
+        } else if endedInATie {
             Image(systemName: "circle.fill")
         } else {
             EmptyView()
@@ -61,6 +65,10 @@ struct LegsCellView_Previews: PreviewProvider {
     private static let leg = MatchLeg(homeParticipant: MockData.antriksh, awayParticipant: MockData.neeraj)
     
     static var previews: some View {
-        LegsCellView(leg: leg)
+        LegsCellView(homeParticipant: leg.homeParticipant,
+                     awayParticipant: leg.awayParticipant,
+                     legState: leg.legState,
+                     winner: leg.winner,
+                     endedInATie: leg.endedInATie)
     }
 }

--- a/Champion/Views/MatchLegProgressView.swift
+++ b/Champion/Views/MatchLegProgressView.swift
@@ -35,7 +35,11 @@ struct MatchLegProgressView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 42) {
-                LegsCellView(leg: matchLeg)
+                LegsCellView(homeParticipant: matchLeg.homeParticipant,
+                             awayParticipant: matchLeg.awayParticipant,
+                             legState: matchLeg.legState,
+                             winner: matchLeg.winner,
+                             endedInATie: matchLeg.endedInATie)
                 
                 PageSection(headerText: "Score Card") {
                     ScoreCellView(participant1Score: matchLeg.homeScore, participant2Score: matchLeg.awayScore)

--- a/Champion/Views/MatchProgressView.swift
+++ b/Champion/Views/MatchProgressView.swift
@@ -20,7 +20,11 @@ struct MatchProgressView: View {
                         NavigationLink {
                             MatchLegProgressView(matchLeg: leg, legNumber: match.legs.firstIndex(where: { $0 == leg.wrappedValue })! + 1)
                         } label: {
-                            LegsCellView(leg: leg.wrappedValue)
+                            LegsCellView(homeParticipant: leg.wrappedValue.homeParticipant,
+                                         awayParticipant: leg.wrappedValue.awayParticipant,
+                                         legState: leg.wrappedValue.legState,
+                                         winner: leg.wrappedValue.winner,
+                                         endedInATie: leg.wrappedValue.endedInATie)
                         }
                         .buttonStyle(.plain)
                     }


### PR DESCRIPTION
For some reason, when I pass in a MatchLeg object directly to the LegCellView, when the leg's state changes (within the environment object), it does not trigger a refresh of the LegCellView (even though it triggers a refresh of all the parent views). This results in a bug within the app where the LegCellView does not automatically turn green when the leg is complete. Additionally, a star does not automatically show next to the winner when the leg is complete.

After a considerable amount of time debugging, I decided to pass in the individual properties from the MatchLeg object into the LegCellView. Interestingly, this resulted in the LegCellView to start working as intended. Now, the LegCellView automatically turns green and a star appears next to the winner's name upon completing the leg.

I'm not quite sure why this change fixed the bug, but here we are. Additionally, another implementation that I tried that fixed the bug was to convert the `let leg: MatchLeg` property into a binding: `@Binding var leg: MatchLeg`. Just this change alone made the LegsCellView work as intended as well. However, I decided to not go with that approach because the fundamentally, the LegsCellView is readonly, and making its property a binding felt hacky.

Anyways, if anyone can show me why this works and the original implementation doesn't, that would be greatly appreciated!